### PR TITLE
Fixed haddock code examples

### DIFF
--- a/src/Pipes/Network/TCP/Safe.hs
+++ b/src/Pipes/Network/TCP/Safe.hs
@@ -143,7 +143,7 @@ acceptFork lsock k = liftIO (S.acceptFork lsock k)
 -- prints whatever is received from a single TCP connection to a given server
 -- listening locally on port 9000, in chunks of up to 4096 bytes:
 --
--- >>> runSafeIO . runProxy . runEitherK $ connectRead Nothing 4096 "127.0.0.1" "9000" >-> tryK printD
+-- >>> runSafeT . run $ connectRead Nothing 4096 "127.0.0.1" "9000" >-> P.show >-> P.stdout
 connectRead
   :: (Ps.MonadSafe m, Ps.Base m ~ IO)
   => Int                -- ^Maximum number of bytes to receive and send
@@ -166,7 +166,7 @@ connectRead nbytes host port = do
 -- greets a TCP client listening locally at port 9000:
 --
 -- >>> :set -XOverloadedStrings
--- >>> runSafeIO . runProxy . runEitherK $ fromListS ["He","llo\r\n"] >-> connectWrite Nothing "127.0.0.1" "9000"
+-- >>> runSafeT . run $ each ["He","llo\r\n"] >-> connectWrite Nothing "127.0.0.1" "9000"
 connectWrite
   :: (Ps.MonadSafe m, Ps.Base m ~ IO)
   => NS.HostName        -- ^Server host name.
@@ -202,7 +202,7 @@ connectWrite hp port = do
 -- chunks of up to 4096 bytes.
 --
 -- >>> :set -XOverloadedStrings
--- >>> runSafeIO . runProxy . runEitherK $ serveRead Nothing 4096 "127.0.0.1" "9000" >-> tryK printD
+-- >>> runSafeT . run $ serveRead Nothing 4096 "127.0.0.1" "9000" >-> P.show >-> P.stdout
 serveRead
   :: (Ps.MonadSafe m, Ps.Base m ~ IO)
   => Int                -- ^Maximum number of bytes to receive and send
@@ -227,7 +227,7 @@ serveRead nbytes hp port = do
 -- greets a TCP client connecting to port 9000:
 --
 -- >>> :set -XOverloadedStrings
--- >>> runSafeIO . runProxy . runEitherK $ fromListS ["He","llo\r\n"] >-> serveWrite Nothing "127.0.0.1" "9000"
+-- >>> runSafeT . run $ each ["He","llo\r\n"] >-> serveWrite Nothing "127.0.0.1" "9000"
 serveWrite
   :: (Ps.MonadSafe m, Ps.Base m ~ IO)
   => S.HostPreference   -- ^Preferred host to bind.


### PR DESCRIPTION
There was one thing I wasn't sure about, which is how to qualify the commands from `Pipes.Prelude`.  Right now I use `P.` and assume that the reader implicitly knows they are from `Pipes.Prelude`, but if you want I can change that.
