### PR TITLE
Updated the documentation to refer to pipes instead of proxies

### DIFF
--- a/pipes-network.cabal
+++ b/pipes-network.cabal
@@ -19,11 +19,11 @@ description:
   .
   This package is organized using the following namespaces:
   .
-  * "Pipes.Network.TCP" exports 'Pipes.Proxy's and functions for
+  * "Pipes.Network.TCP" exports pipes and functions for
   establishing and using TCP connections.
   .
   * "Pipes.Network.TCP.Safe" is similar to "Pipes.Network.TCP", except
-  the exported 'Pipes.Proxy's themselves can obtain new network
+  the exported pipes themselves can obtain new network
   resources safely by using the facilities providied by the @pipes-safe@
   package.
   .

--- a/src/Pipes/Network/TCP.hs
+++ b/src/Pipes/Network/TCP.hs
@@ -5,9 +5,9 @@
 -- the "Network.Simple.TCP" module from the @network-simple@ package.
 --
 -- This module /does not/ export facilities that would allow you to acquire new
--- 'NS.Socket's within a 'Proxy' pipeline. If you need to do so, then you'll
--- need to rely on additional features exported the "Pipes.Network.TCP.Safe"
--- module, which among other things, overrides some of the functions from
+-- 'NS.Socket's within a pipeline. If you need to do so, then you'll need to
+-- rely on additional features exported the "Pipes.Network.TCP.Safe" module,
+-- which among other things, overrides some of the functions from
 -- "Network.Simple.TCP".
 
 module Pipes.Network.TCP (
@@ -31,9 +31,9 @@ import           Pipes.Core
 
 -- $receiving
 --
--- The following 'Proxy's allow you to receive bytes from the remote end.
+-- The following pipes allow you to receive bytes from the remote end.
 --
--- Besides the 'Proxy's exported below, you might want to 'liftIO'
+-- Besides the pipes exported below, you might want to 'liftIO'
 -- "Network.Simple.TCP"'s 'Network.Simple.TCP.recv' to be used as an 'Effect':
 --
 -- @
@@ -69,7 +69,7 @@ fromSocket sock nbytes = loop where
 {-# INLINABLE fromSocket #-}
 
 
--- | Like 'fromSocket', except the downstream 'Proxy' can specify the maximum
+-- | Like 'fromSocket', except the downstream pipe can specify the maximum
 -- number of bytes to receive at once using 'request'.
 fromSocketN :: MonadIO m => NS.Socket -> Int -> Server Int B.ByteString m ()
 fromSocketN sock = loop where
@@ -84,9 +84,9 @@ fromSocketN sock = loop where
 
 -- $sending
 --
--- The following 'Proxy's allow you to send bytes to the remote end.
+-- The following pipes allow you to send bytes to the remote end.
 --
--- Besides the 'Proxy's below, you might want to 'liftIO' "Network.Simple.TCP"'s
+-- Besides the pipes below, you might want to 'liftIO' "Network.Simple.TCP"'s
 -- 'Network.Simple.TCP.send' to be used as an 'Effect':
 --
 -- @

--- a/src/Pipes/Network/TCP/Safe.hs
+++ b/src/Pipes/Network/TCP/Safe.hs
@@ -128,7 +128,7 @@ acceptFork lsock k = liftIO (S.acceptFork lsock k)
 
 -- $client-streaming
 --
--- The following proxies allow you to easily connect to a TCP server and
+-- The following pipes allow you to easily connect to a TCP server and
 -- immediately interact with it in a streaming fashion, all at once, instead of
 -- having to perform the individual steps separately.
 
@@ -139,9 +139,9 @@ acceptFork lsock k = liftIO (S.acceptFork lsock k)
 --
 -- The connection socket is closed when done or in case of exceptions.
 --
--- Using this proxy you can write straightforward code like the following, which
--- prints whatever is received from a single TCP connection to a given server
--- listening locally on port 9000, in chunks of up to 4096 bytes:
+-- Using this 'Producer' you can write straightforward code like the following,
+-- which prints whatever is received from a single TCP connection to a given
+-- server listening locally on port 9000, in chunks of up to 4096 bytes:
 --
 -- >>> runSafeT . run $ connectRead Nothing 4096 "127.0.0.1" "9000" >-> P.show >-> P.stdout
 connectRead
@@ -162,8 +162,8 @@ connectRead nbytes host port = do
 --
 -- The connection socket is closed in case of exceptions.
 --
--- Using this proxy you can write straightforward code like the following, which
--- greets a TCP client listening locally at port 9000:
+-- Using this 'Consumer' you can write straightforward code like the following,
+-- which greets a TCP client listening locally at port 9000:
 --
 -- >>> :set -XOverloadedStrings
 -- >>> runSafeT . run $ each ["He","llo\r\n"] >-> connectWrite Nothing "127.0.0.1" "9000"
@@ -180,7 +180,7 @@ connectWrite hp port = do
 
 -- $server-streaming
 --
--- The following proxies allow you to easily run a TCP server and immediately
+-- The following pipes allow you to easily run a TCP server and immediately
 -- interact with incoming connections in a streaming fashion, all at once,
 -- instead of having to perform the individual steps separately.
 
@@ -191,15 +191,15 @@ connectWrite hp port = do
 --
 -- Less than the specified maximum number of bytes might be received at once.
 --
--- This proxy returns if the remote peer closes its side of the connection or
--- EOF is received.
+-- This 'Producer' returns if the remote peer closes its side of the connection
+-- or EOF is received.
 --
 -- Both the listening and connection sockets are closed when done or in case of
 -- exceptions.
 --
--- Using this proxy you can write straightforward code like the following, which
--- prints whatever is received from a single TCP connection to port 9000, in
--- chunks of up to 4096 bytes.
+-- Using this 'Producer' you can write straightforward code like the following,
+-- which prints whatever is received from a single TCP connection to port 9000,
+-- in chunks of up to 4096 bytes.
 --
 -- >>> :set -XOverloadedStrings
 -- >>> runSafeT . run $ serveRead Nothing 4096 "127.0.0.1" "9000" >-> P.show >-> P.stdout
@@ -223,8 +223,8 @@ serveRead nbytes hp port = do
 -- Both the listening and connection sockets are closed when done or in case of
 -- exceptions.
 --
--- Using this proxy you can write straightforward code like the following, which
--- greets a TCP client connecting to port 9000:
+-- Using this 'Consumer' you can write straightforward code like the following,
+-- which greets a TCP client connecting to port 9000:
 --
 -- >>> :set -XOverloadedStrings
 -- >>> runSafeT . run $ each ["He","llo\r\n"] >-> serveWrite Nothing "127.0.0.1" "9000"


### PR DESCRIPTION
The word 'Proxy' is used very sparingly in the new `pipes` tutorial, so I created a pull request to  documentation to use the lower-case word "pipes" as a replacement so that beginners don't get confused about what `Proxy` refers to.

This pull request is just a suggestion since you may prefer the use of the term `Proxy`.
