### PR TITLE
Bump upper bounds for `transformers`

### DIFF
--- a/pipes-network.cabal
+++ b/pipes-network.cabal
@@ -44,7 +44,7 @@ library
         network-simple (>=0.3 && <0.4),
         pipes          (>=4.0 && <4.2),
         pipes-safe     (>=2.1 && <2.2),
-        transformers   (>=0.2 && <0.4)
+        transformers   (>=0.2 && <0.5)
     exposed-modules:
         Pipes.Network.TCP
         Pipes.Network.TCP.Safe


### PR DESCRIPTION
This assumes `network-simple`, `pipes` and `pipes-safe` have been already bumped.
